### PR TITLE
feat(business-data): add DataForm and EditModal for entry & editing

### DIFF
--- a/src/app/business-data/DataForm.js
+++ b/src/app/business-data/DataForm.js
@@ -1,0 +1,199 @@
+"use client";
+import { useState } from "react";
+import axios from "axios";
+
+export default function DataForm({ onDataSaved }) {
+  const [form, setForm] = useState({
+    revenue: ["", "", "", "", "", ""],
+    costs: ["", "", "", "", "", ""],
+    kpis: {
+      total_revenue: "",
+      total_costs: "",
+      profit_margin: "",
+      growth_rate: "",
+    },
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  const handleChange = (type, idx, value) => {
+    if (type === "revenue" || type === "costs") {
+      setForm((f) => ({
+        ...f,
+        [type]: f[type].map((v, i) => (i === idx ? value : v)),
+      }));
+    } else {
+      setForm((f) => ({ ...f, kpis: { ...f.kpis, [type]: value } }));
+    }
+    setSuccess(false);
+    setError("");
+  };
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      // Validation
+      if (form.revenue.some((r) => !r) || form.costs.some((c) => !c)) {
+        setError("Please fill in all revenue and cost fields.");
+        setLoading(false);
+        return;
+      }
+
+      // Format data for API
+      const data = {
+        revenue: {
+          labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+          values: form.revenue.map(Number),
+        },
+        costs: {
+          labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+          values: form.costs.map(Number),
+        },
+        kpis: {
+          total_revenue: Number(form.kpis.total_revenue),
+          total_costs: Number(form.kpis.total_costs),
+          profit_margin: Number(form.kpis.profit_margin),
+          growth_rate: Number(form.kpis.growth_rate),
+        },
+        last_updated: new Date().toISOString(),
+      };
+
+      // Send to API
+      const formData = new FormData();
+      formData.append(
+        "file",
+        new Blob([JSON.stringify(data)], { type: "application/json" }),
+        "data.json"
+      );
+      await axios.post("/api/data/upload", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+
+      setSuccess(true);
+      setLoading(false);
+      onDataSaved && onDataSaved();
+    } catch (err) {
+      setError("Failed to save data. Please check your input and try again.");
+      setLoading(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 rounded-lg p-8 text-center">
+        <div className="text-green-600 dark:text-green-400 text-4xl mb-4">
+          ✓
+        </div>
+        <h3 className="text-lg font-semibold text-green-800 dark:text-green-200 mb-2">
+          Data Saved Successfully!
+        </h3>
+        <p className="text-green-700 dark:text-green-300 mb-4">
+          Your business data has been processed and stored.
+        </p>
+        <p className="text-sm text-green-600 dark:text-green-400">
+          Redirecting to dashboard...
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="bg-white dark:bg-gray-900 rounded-lg shadow-lg p-8"
+      onSubmit={handleSubmit}
+    >
+      {/* Revenue Section */}
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">
+          Monthly Revenue
+        </h2>
+        <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
+          {form.revenue.map((val, i) => (
+            <div key={i}>
+              <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+                {["Jan", "Feb", "Mar", "Apr", "May", "Jun"][i]}
+              </label>
+              <input
+                type="number"
+                required
+                min={0}
+                value={val}
+                onChange={(e) => handleChange("revenue", i, e.target.value)}
+                className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Costs Section */}
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">
+          Monthly Costs
+        </h2>
+        <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
+          {form.costs.map((val, i) => (
+            <div key={i}>
+              <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+                {["Jan", "Feb", "Mar", "Apr", "May", "Jun"][i]}
+              </label>
+              <input
+                type="number"
+                required
+                min={0}
+                value={val}
+                onChange={(e) => handleChange("costs", i, e.target.value)}
+                className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* KPIs Section */}
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">
+          Key Performance Indicators
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {Object.entries(form.kpis).map(([key, val]) => (
+            <div key={key}>
+              <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1 capitalize">
+                {key.replace("_", " ")}
+              </label>
+              <input
+                type="number"
+                required
+                min={0}
+                step="0.01"
+                value={val}
+                onChange={(e) => handleChange(key, null, e.target.value)}
+                className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Error Display */}
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 rounded text-red-700 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Submit Button */}
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-semibold py-3 px-6 rounded-lg transition duration-200"
+      >
+        {loading ? "Saving Data..." : "Save Data & View Dashboard"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/business-data/UploadPanel.js
+++ b/src/app/business-data/UploadPanel.js
@@ -1,0 +1,196 @@
+// "use client";
+// import { useState } from "react";
+// import axios from "axios";
+
+// export default function UploadPanel({ onUploadSuccess }) {
+//   const [file, setFile] = useState(null);
+//   const [progress, setProgress] = useState(null);
+//   const [error, setError] = useState("");
+//   const [success, setSuccess] = useState(false);
+
+//   const onFileChange = (e) => {
+//     setFile(e.target.files[0]);
+//     setSuccess(false);
+//     setError("");
+//     setProgress(null);
+//   };
+
+//   const handleUpload = async () => {
+//     setError("");
+//     setSuccess(false);
+//     setProgress("Uploading...");
+//     if (!file) {
+//       setError("Please select a JSON file.");
+//       setProgress(null);
+//       return;
+//     }
+//     try {
+//       const formData = new FormData();
+//       formData.append("file", file);
+
+//       await axios.post("/api/data/upload", formData, {
+//         headers: { "Content-Type": "multipart/form-data" },
+//       });
+//       setProgress(null);
+//       setSuccess(true);
+//       onUploadSuccess && onUploadSuccess();
+//     } catch (e) {
+//       setProgress(null);
+//       setError("File upload failed. Please check your file format.");
+//     }
+//   };
+
+//   return (
+//     <div className="bg-white dark:bg-gray-900 p-6 rounded-lg shadow">
+//       <label className="block mb-2">Upload Financial Data (JSON)</label>
+//       <input
+//         type="file"
+//         accept=".json,application/json"
+//         onChange={onFileChange}
+//         className="mb-4"
+//       />
+//       {progress && <div className="text-blue-600 mb-2">{progress}</div>}
+//       {error && <div className="text-red-600 mb-2">{error}</div>}
+//       {success && (
+//         <div className="text-green-600 mb-2">File uploaded successfully!</div>
+//       )}
+//       <button
+//         type="button"
+//         className="mt-2 px-4 py-2 rounded bg-blue-600 text-white"
+//         onClick={handleUpload}
+//       >
+//         Upload File
+//       </button>
+//     </div>
+//   );
+// }
+
+"use client";
+import { useState } from "react";
+import axios from "axios";
+
+export default function UploadPanel({ onUploadSuccess }) {
+  const [file, setFile] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  const onFileChange = (e) => {
+    setFile(e.target.files[0]);
+    setSuccess(false);
+    setError("");
+  };
+
+  const handleUpload = async () => {
+    if (!file) {
+      setError("Please select a JSON file first.");
+      return;
+    }
+
+    setError("");
+    setLoading(true);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      await axios.post("/api/data/upload", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+
+      setLoading(false);
+      setSuccess(true);
+      onUploadSuccess && onUploadSuccess();
+    } catch (e) {
+      setLoading(false);
+      setError("Upload failed. Please check your file format and try again.");
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 rounded-lg p-8 text-center">
+        <div className="text-green-600 dark:text-green-400 text-4xl mb-4">
+          ✓
+        </div>
+        <h3 className="text-lg font-semibold text-green-800 dark:text-green-200 mb-2">
+          File Uploaded Successfully!
+        </h3>
+        <p className="text-green-700 dark:text-green-300 mb-4">
+          Your data file has been processed and stored.
+        </p>
+        <p className="text-sm text-green-600 dark:text-green-400">
+          Redirecting to dashboard...
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-lg shadow-lg p-8">
+      <div className="text-center mb-6">
+        <div className="mx-auto w-16 h-16 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center mb-4">
+          <span className="text-2xl">📄</span>
+        </div>
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
+          Upload Financial Data
+        </h2>
+        <p className="text-gray-600 dark:text-gray-400 text-sm">
+          Select a JSON file containing your business data
+        </p>
+      </div>
+
+      <div className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 text-center">
+        <input
+          type="file"
+          accept=".json,application/json"
+          onChange={onFileChange}
+          className="mb-4 w-full"
+        />
+
+        {file && (
+          <div className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            Selected: {file.name}
+          </div>
+        )}
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 rounded text-red-700 dark:text-red-300 text-sm">
+            {error}
+          </div>
+        )}
+
+        <button
+          onClick={handleUpload}
+          disabled={!file || loading}
+          className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white font-semibold py-3 px-6 rounded-lg transition duration-200"
+        >
+          {loading ? "Uploading..." : "Upload & View Dashboard"}
+        </button>
+      </div>
+
+      {/* JSON Format Help */}
+      <div className="mt-6 p-4 bg-gray-50 dark:bg-gray-800 rounded text-sm">
+        <h4 className="font-medium mb-2">Expected JSON Format:</h4>
+        <pre className="text-xs text-gray-600 dark:text-gray-400">
+          {`{
+  "revenue": {
+    "labels": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    "values": [12000, 15000, 18000, 20000, 22000, 30000]
+  },
+  "costs": {
+    "labels": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"], 
+    "values": [8000, 9000, 11000, 12000, 13000, 14000]
+  },
+  "kpis": {
+    "total_revenue": 117000,
+    "total_costs": 67000,
+    "profit_margin": 42.7,
+    "growth_rate": 18.3
+  }
+}`}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/src/app/business-data/page.js
+++ b/src/app/business-data/page.js
@@ -1,0 +1,177 @@
+// "use client";
+// import { useState, useEffect } from "react";
+// import { useRouter, useSearchParams } from "next/navigation";
+// import axios from "axios";
+// import DataForm from "./DataForm";
+// import UploadPanel from "./UploadPanel";
+
+// export default function AddDataPage() {
+//   const [mode, setMode] = useState("manual");
+//   const [editMode, setEditMode] = useState(false);
+//   const [existingData, setExistingData] = useState(null);
+//   const router = useRouter();
+//   const searchParams = useSearchParams();
+
+//   // Check if we're in edit mode (via URL parameter ?edit=true)
+//   useEffect(() => {
+//     const isEdit = searchParams.get("edit") === "true";
+//     if (isEdit) {
+//       setEditMode(true);
+//       // Fetch existing data
+//       axios
+//         .get("/api/dashboard/metrics")
+//         .then((res) => setExistingData(res.data))
+//         .catch((err) => console.error("Failed to load existing data:", err));
+//     }
+//   }, [searchParams]);
+
+//   const handleDataSaved = () => {
+//     setTimeout(() => {
+//       router.push("/dashboard");
+//     }, 1500);
+//   };
+
+//   return (
+//     <div className="max-w-3xl mx-auto px-4 py-8">
+//       <div className="text-center mb-8">
+//         <h1 className="text-3xl font-bold mb-2">
+//           {editMode ? "Update Your Business Data" : "Add Your Business Data"}
+//         </h1>
+//         <p className="text-gray-600">
+//           {editMode
+//             ? "Modify your existing financial data"
+//             : "Enter your financial data manually or upload a JSON file"}
+//         </p>
+//       </div>
+
+//       {/* Mode Selection - Hide upload in edit mode */}
+//       <div className="flex justify-center mb-8">
+//         <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-1 flex">
+//           <button
+//             onClick={() => setMode("manual")}
+//             className={`px-6 py-2 rounded-md font-medium transition ${
+//               mode === "manual"
+//                 ? "bg-white dark:bg-gray-700 text-blue-600 shadow"
+//                 : "text-gray-600 hover:text-gray-900"
+//             }`}
+//           >
+//             {editMode ? "Edit Data" : "Manual Entry"}
+//           </button>
+//           {!editMode && (
+//             <button
+//               onClick={() => setMode("upload")}
+//               className={`px-6 py-2 rounded-md font-medium transition ${
+//                 mode === "upload"
+//                   ? "bg-white dark:bg-gray-700 text-blue-600 shadow"
+//                   : "text-gray-600 hover:text-gray-900"
+//               }`}
+//             >
+//               Upload File
+//             </button>
+//           )}
+//         </div>
+//       </div>
+
+//       <div className="mb-8">
+//         {mode === "manual" ? (
+//           <DataForm
+//             onDataSaved={handleDataSaved}
+//             editMode={editMode}
+//             existingData={existingData}
+//           />
+//         ) : (
+//           <UploadPanel onUploadSuccess={handleDataSaved} />
+//         )}
+//       </div>
+//     </div>
+//   );
+// }
+
+"use client";
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import DataForm from "./DataForm";
+import UploadPanel from "./UploadPanel";
+
+export default function BusinessDataPage() {
+  const [mode, setMode] = useState("manual");
+  const [editMode, setEditMode] = useState(false);
+  const [existingData, setExistingData] = useState(null);
+  const router = useRouter();
+  const params = useSearchParams();
+
+  // Detect edit mode and load existing dashboard metrics
+  useEffect(() => {
+    if (params.get("edit") === "true") {
+      setEditMode(true);
+      // Fetch current dashboard metrics for pre-population
+      fetch("/api/dashboard/metrics")
+        .then((res) => res.json())
+        .then((data) => setExistingData(data))
+        .catch(() => console.error("Failed to load existing data"));
+      // Force manual mode when editing
+      setMode("manual");
+    }
+  }, [params]);
+
+  const handleDataSaved = () => {
+    // After save, redirect back to dashboard
+    setTimeout(() => {
+      router.push("/dashboard");
+    }, 1200);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">
+        {editMode ? "Update Your Business Data" : "Add Your Business Data"}
+      </h1>
+      <p className="text-gray-600 mb-8">
+        {editMode
+          ? "Modify your existing financial data below"
+          : "Enter your financial data manually or upload a JSON file"}
+      </p>
+
+      {/* Tabs: hide Upload when editing */}
+      <div className="flex space-x-4 mb-8">
+        <button
+          onClick={() => setMode("manual")}
+          className={`px-4 py-2 rounded ${
+            mode === "manual"
+              ? "bg-blue-600 text-white"
+              : "bg-gray-200 text-gray-700"
+          }`}
+        >
+          {editMode ? "Edit Data" : "Manual Entry"}
+        </button>
+
+        {!editMode && (
+          <button
+            onClick={() => setMode("upload")}
+            className={`px-4 py-2 rounded ${
+              mode === "upload"
+                ? "bg-blue-600 text-white"
+                : "bg-gray-200 text-gray-700"
+            }`}
+          >
+            Upload File
+          </button>
+        )}
+      </div>
+
+      {/* Render DataForm only when (not editing) or existingData loaded */}
+      {mode === "manual" && (!editMode || existingData) && (
+        <DataForm
+          onDataSaved={handleDataSaved}
+          editMode={editMode}
+          existingData={existingData}
+        />
+      )}
+
+      {/* Only show upload option when not editing */}
+      {mode === "upload" && !editMode && (
+        <UploadPanel onUploadSuccess={handleDataSaved} />
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/EditModal.js
+++ b/src/app/dashboard/EditModal.js
@@ -1,0 +1,336 @@
+// "use client";
+// import { useState, useEffect } from "react";
+// import axios from "axios";
+
+// export default function EditModal({
+//   isOpen,
+//   onClose,
+//   currentData,
+//   onDataUpdated,
+// }) {
+//   const [form, setForm] = useState({
+//     revenue: ["", "", "", "", "", ""],
+//     costs: ["", "", "", "", "", ""],
+//     kpis: {
+//       total_revenue: "",
+//       total_costs: "",
+//       profit_margin: "",
+//       growth_rate: "",
+//     },
+//   });
+//   const [loading, setLoading] = useState(false);
+
+//   useEffect(() => {
+//     if (currentData) {
+//       setForm({
+//         revenue: currentData.revenue.values.map(String),
+//         costs: currentData.costs.values.map(String),
+//         kpis: {
+//           total_revenue: String(currentData.kpis.total_revenue),
+//           total_costs: String(currentData.kpis.total_costs),
+//           profit_margin: String(currentData.kpis.profit_margin),
+//           growth_rate: String(currentData.kpis.growth_rate),
+//         },
+//       });
+//     }
+//   }, [currentData]);
+
+//   const handleSubmit = async (e) => {
+//     e.preventDefault();
+//     setLoading(true);
+
+//     try {
+//       const data = {
+//         revenue: {
+//           labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+//           values: form.revenue.map(Number),
+//         },
+//         costs: {
+//           labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+//           values: form.costs.map(Number),
+//         },
+//         kpis: {
+//           total_revenue: Number(form.kpis.total_revenue),
+//           total_costs: Number(form.kpis.total_costs),
+//           profit_margin: Number(form.kpis.profit_margin),
+//           growth_rate: Number(form.kpis.growth_rate),
+//         },
+//         last_updated: new Date().toISOString(),
+//       };
+
+//       const formData = new FormData();
+//       formData.append(
+//         "file",
+//         new Blob([JSON.stringify(data)], { type: "application/json" }),
+//         "data.json"
+//       );
+//       await axios.post("/api/data/upload", formData, {
+//         headers: { "Content-Type": "multipart/form-data" },
+//       });
+
+//       setLoading(false);
+//       onDataUpdated();
+//       onClose();
+//     } catch (err) {
+//       setLoading(false);
+//       alert("Failed to update data");
+//     }
+//   };
+
+//   if (!isOpen) return null;
+
+//   return (
+//     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+//       <div className="bg-white dark:bg-gray-900 rounded-lg p-6 max-w-2xl w-full max-h-90vh overflow-y-auto">
+//         <div className="flex justify-between items-center mb-4">
+//           <h2 className="text-xl font-bold">Edit Business Data</h2>
+//           <button
+//             onClick={onClose}
+//             className="text-gray-500 hover:text-gray-700"
+//           >
+//             ✕
+//           </button>
+//         </div>
+
+//         <form onSubmit={handleSubmit}>
+//           {/* Compact form fields here - similar to DataForm but more condensed */}
+//           <button
+//             type="submit"
+//             disabled={loading}
+//             className="w-full bg-blue-600 text-white py-2 rounded"
+//           >
+//             {loading ? "Updating..." : "Update Data"}
+//           </button>
+//         </form>
+//       </div>
+//     </div>
+//   );
+// }
+
+// src/app/dashboard/EditModal.js
+"use client";
+
+import { useState, useEffect } from "react";
+import axios from "axios";
+
+export default function EditModal({
+  isOpen,
+  onClose,
+  currentData,
+  onDataUpdated,
+}) {
+  const [form, setForm] = useState({
+    revenue: ["", "", "", "", "", ""],
+    costs: ["", "", "", "", "", ""],
+    kpis: {
+      total_revenue: "",
+      total_costs: "",
+      profit_margin: "",
+      growth_rate: "",
+    },
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  // Pre-populate form when currentData changes
+  useEffect(() => {
+    if (currentData) {
+      setForm({
+        revenue: currentData.revenue.values.map(String),
+        costs: currentData.costs.values.map(String),
+        kpis: {
+          total_revenue: String(currentData.kpis.total_revenue),
+          total_costs: String(currentData.kpis.total_costs),
+          profit_margin: String(currentData.kpis.profit_margin),
+          growth_rate: String(currentData.kpis.growth_rate),
+        },
+      });
+      setError("");
+    }
+  }, [currentData]);
+
+  const handleChange = (section, idxOrKey, value) => {
+    if (section === "revenue" || section === "costs") {
+      setForm((f) => ({
+        ...f,
+        [section]: f[section].map((v, i) => (i === idxOrKey ? value : v)),
+      }));
+    } else {
+      setForm((f) => ({
+        ...f,
+        kpis: { ...f.kpis, [idxOrKey]: value },
+      }));
+    }
+    setError("");
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    // Basic validation
+    if (
+      form.revenue.some((v) => v === "") ||
+      form.costs.some((v) => v === "")
+    ) {
+      setError("All revenue and cost fields are required.");
+      setLoading(false);
+      return;
+    }
+    if (Object.values(form.kpis).some((v) => v === "")) {
+      setError("All KPI fields are required.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const dataPayload = {
+        revenue: {
+          labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+          values: form.revenue.map(Number),
+        },
+        costs: {
+          labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+          values: form.costs.map(Number),
+        },
+        kpis: {
+          total_revenue: Number(form.kpis.total_revenue),
+          total_costs: Number(form.kpis.total_costs),
+          profit_margin: Number(form.kpis.profit_margin),
+          growth_rate: Number(form.kpis.growth_rate),
+        },
+        last_updated: new Date().toISOString(),
+      };
+
+      const fd = new FormData();
+      fd.append(
+        "file",
+        new Blob([JSON.stringify(dataPayload)], { type: "application/json" }),
+        "data.json"
+      );
+
+      await axios.post("/api/data/upload", fd, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+
+      setLoading(false);
+      onDataUpdated();
+      onClose();
+    } catch (err) {
+      console.error(err);
+      setError("Failed to update data. Please try again.");
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-lg p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">Edit Business Data</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Revenue Inputs */}
+          <div>
+            <h3 className="font-semibold mb-2">Monthly Revenue</h3>
+            <div className="grid grid-cols-3 gap-2">
+              {form.revenue.map((val, idx) => (
+                <input
+                  key={idx}
+                  type="number"
+                  min={0}
+                  value={val}
+                  onChange={(e) => handleChange("revenue", idx, e.target.value)}
+                  placeholder={["Jan", "Feb", "Mar", "Apr", "May", "Jun"][idx]}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                  required
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Costs Inputs */}
+          <div>
+            <h3 className="font-semibold mb-2">Monthly Costs</h3>
+            <div className="grid grid-cols-3 gap-2">
+              {form.costs.map((val, idx) => (
+                <input
+                  key={idx}
+                  type="number"
+                  min={0}
+                  value={val}
+                  onChange={(e) => handleChange("costs", idx, e.target.value)}
+                  placeholder={["Jan", "Feb", "Mar", "Apr", "May", "Jun"][idx]}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                  required
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* KPI Inputs */}
+          <div>
+            <h3 className="font-semibold mb-2">Key Performance Indicators</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              {Object.entries(form.kpis).map(([key, val]) => (
+                <div key={key}>
+                  <label className="block text-sm font-medium mb-1 capitalize text-gray-700 dark:text-gray-300">
+                    {key.replace("_", " ")}
+                  </label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    value={val}
+                    onChange={(e) => handleChange("kpis", key, e.target.value)}
+                    className="w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                    required
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Error Message */}
+          {error && (
+            <div className="text-red-600 bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 p-3 rounded">
+              {error}
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          <div className="flex space-x-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-gray-200 py-2 rounded hover:bg-gray-400 transition"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex-1 bg-blue-600 hover:bg-blue-700 text-white py-2 rounded disabled:opacity-50 transition"
+            >
+              {loading ? "Updating..." : "Update Data"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Introduce a new **DataForm** component that handles manual revenue/cost input, KPI fields, validation, and uploads the data as JSON via an API call. It provides loading, error, and success feedback and integrates with the existing page to toggle between manual entry and file upload modes.

Add an **EditModal** component to enable editing of existing business data entries directly from the dashboard. Both components improve the user workflow for creating and updating financial data within the application.